### PR TITLE
Adding Ace editor for CSS, cleaning up specs.

### DIFF
--- a/app/assets/stylesheets/spree/backend/dandify.scss
+++ b/app/assets/stylesheets/spree/backend/dandify.scss
@@ -1,4 +1,13 @@
 /* Icon rollover - Restore */
+
+.spree-ace-field {
+  position: relative;
+}
+#editor {
+  position: absolute;
+  top: 24px; right: 0; left: 0; bottom: 46px;
+}
+
 table th.actions,
 table td.actions {
   .fa-history:hover {

--- a/app/controllers/spree/admin/stylesheets_controller.rb
+++ b/app/controllers/spree/admin/stylesheets_controller.rb
@@ -5,7 +5,7 @@ module Spree
 
       respond_to :html
 
-      before_action :set_style
+      before_action :set_style, except: [:restore]
 
       def create
         update_action :new
@@ -13,6 +13,14 @@ module Spree
 
       def update
         update_action :edit
+      end
+
+      def destroy
+        @style.destroy
+
+        redirect_to admin_stylesheets_path, flash: {
+          success: Spree.t('dandify.admin.flash.destroyed')
+        }
       end
 
       def restore
@@ -24,13 +32,14 @@ module Spree
       end
 
       def user_for_paper_trail
-        current_spree_user.present? ? current_spree_user.id : 'Unknown'
+        Spree::UserIdentifier.new(current_spree_user).id
       end
 
       private
 
       def rollback_version
-        @style.versions.last.reify.save!
+        @style = PaperTrail::Version.find(params[:id]).reify
+        @style.save!
         :success
       rescue
         :error

--- a/app/helpers/spree/admin/navigation_helper_decorator.rb
+++ b/app/helpers/spree/admin/navigation_helper_decorator.rb
@@ -1,9 +1,25 @@
 Spree::Admin::NavigationHelper.class_eval do
   def link_to_restore_url(url, options = {})
     name = options[:name] || Spree.t('dandify.admin.icons.restore')
-    options[:class] = 'restore-resource'
+    options[:class] = 'restore-resource btn btn-sm btn-primary icon icon-clone'
     options[:data] = { confirm: Spree.t('dandify.admin.confirm.restore'),
-                        action:  'restore' }
+                        action: 'restore' }
     link_to_with_icon('history', name, url, options)
+  end
+
+  def link_to_destroy_url
+    options = {
+      class: 'btn btn-danger',
+      data: {
+        confirm: Spree.t('dandify.admin.confirm.destroy'),
+        action: 'delete'
+      },
+      method: :delete
+    }
+
+    link_to_with_icon 'delete',
+                      Spree.t('dandify.admin.icons.destroy'),
+                      admin_stylesheets_path,
+                      options
   end
 end

--- a/app/helpers/spree/admin/stylesheet_helper.rb
+++ b/app/helpers/spree/admin/stylesheet_helper.rb
@@ -1,8 +1,18 @@
 module Spree
   module Admin
     module StylesheetHelper
-      def dandify_version_email(user)
-        user.nil? ? Spree.t('dandify.admin.unknown') : user.email
+      def dandify_version_email(user_id)
+        user = if user_id.nil? || user_id == Spree.t('dandify.admin.unknown')
+          UnknownUser.new
+        else
+          User.find(user_id)
+        end
+
+        user.email
+      end
+
+      def previous_versions
+        PaperTrail::Version.all
       end
     end
   end

--- a/app/models/spree/unknown_user.rb
+++ b/app/models/spree/unknown_user.rb
@@ -1,0 +1,11 @@
+module Spree
+  class UnknownUser
+    def id
+      Spree.t('dandify.admin.unknown')
+    end
+
+    def email
+      Spree.t('dandify.admin.unknown')
+    end
+  end
+end

--- a/app/models/spree/user_identifier.rb
+++ b/app/models/spree/user_identifier.rb
@@ -1,0 +1,13 @@
+module Spree
+  class UserIdentifier
+    delegate :id, to: :user
+
+    def initialize(user)
+      @user = user || UnknownUser.new
+    end
+
+    private
+
+    attr_reader :user
+  end
+end

--- a/app/views/spree/admin/stylesheets/_form.html.erb
+++ b/app/views/spree/admin/stylesheets/_form.html.erb
@@ -1,11 +1,33 @@
+<% content_for :head do %>
+  <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/ace.js' %>
+  <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/mode-css.js' %>
+<% end %>
+
 <div data-hook="admin_style_form_fields" class="col-md-12">
   <div class="form-group 12-row">
-    <div data-hook="admin_stylesheet_form_style_raw" class="form-group field">
+    <div data-hook="admin_stylesheet_form_style_raw" class="form-group field spree-ace-field">
+      <div id="editor"></div>
       <%= f.field_container :style_raw, class: ['form-group'] do %>
         <%= f.label :style_raw, Spree.t('dandify.admin.labels.style_raw') %>
-        <%= f.text_area :style_raw, rows: '13', class: 'form-control ' %>
+        <%= f.text_area :style_raw, rows: '13', class: 'form-control' %>
         <br/><span class="help-block"><%= Spree.t('dandify.admin.notes.sass') %></span>
       <% end %>
     </div>
   </div>
 </div>
+
+<script>
+  (function() {
+    var cssEditor, stylesheetText = $("#stylesheet_style_raw");
+
+    $(function() {
+      cssEditor = ace.edit("editor");
+      cssEditor.getSession().setMode("ace/mode/css");
+      cssEditor.setValue(stylesheetText.text());
+    });
+
+    $('#new_stylesheet, .edit_stylesheet').submit(function(event) {
+      stylesheetText.text(cssEditor.getValue());
+    });
+  })();
+</script>

--- a/app/views/spree/admin/stylesheets/_versions.html.erb
+++ b/app/views/spree/admin/stylesheets/_versions.html.erb
@@ -1,22 +1,27 @@
+<h4>
+  <%= Spree.t('dandify.admin.headers.revisions') %>
+</h4>
 <table class="table" id="listing_versions" data-hook="listing_style_versions">
   <thead>
     <tr data-hook="stylesheets_show_index_headers">
-      <th><%= Spree.t('dandify.admin.headers.created_at') %></th>
+      <th><%= Spree.t('dandify.admin.headers.on') %></th>
       <th><%= Spree.t('dandify.admin.headers.author') %></th>
+      <th><%= Spree.t('dandify.admin.headers.action') %></th>
       <th data-hook="admin_stylesheets_show_header_actions" class="actions"></th>
     </tr>
   </thead>
   <tbody>
-  <% versions.reverse.each_with_index do |version, index| %>
+  <% versions.reverse.each_with_index do |version| %>
     <tr data-hook="admin_stylesheets_show_rows" class="<%= cycle('odd', 'even') %>">
-      <td class="align-center"><%= version.created_at.to_date %></td>
-      <td><%= link_to(dandify_version_email(version.user), admin_user_path(version.whodunnit.to_i)) %></td>
+      <td class="align-center">
+        <%= version.created_at.to_date %>
+      </td>
+      <td><%= link_to(dandify_version_email(version.whodunnit), admin_user_path(version.whodunnit.to_i)) %></td>
+      <td>
+        <%= Spree.t("dandify.admin.action.#{version.event}") %>
+      </td>
       <td class='actions align-center' data-hook="admin_stylesheets_show_row_actions">
-      <% if index == 0 %>
-        <%= link_to_edit_url edit_admin_stylesheets_path, title: 'admin_edit_stylesheet', no_text: true %>
-      <% elsif index == 1 %>
-        <%= link_to_restore_url restore_admin_stylesheets_path, title: 'admin_restore_stylesheet', no_text: true, method: :post %>
-      <% end %>
+        <%= link_to_restore_url restore_admin_stylesheets_path(id: version.id), title: 'admin_restore_stylesheet', no_text: true, method: :post %>
       </td>
     </tr>
   <% end %>

--- a/app/views/spree/admin/stylesheets/edit.html.erb
+++ b/app/views/spree/admin/stylesheets/edit.html.erb
@@ -10,7 +10,7 @@
   <fieldset data-hook="edit_style">
     <%= render partial: 'form', locals: {f: f} %>
     <div class="form-buttons filter-actions actions" data-hook="buttons">
-      <%= button Spree.t('actions.update'), 'ok', { class: 'btn-success' } %>
+      <%= button Spree.t('actions.update'), 'ok', 'submit', { class: 'btn-success' } %>
       <span class="or"><%= Spree.t(:or) %></span>
       <%= button_link_to Spree.t('actions.cancel'), admin_stylesheets_path, icon: 'remove' %>
     </div>

--- a/app/views/spree/admin/stylesheets/show.html.erb
+++ b/app/views/spree/admin/stylesheets/show.html.erb
@@ -5,20 +5,33 @@
 <% end %>
 
 <% content_for :page_actions do %>
-<% if @style.persisted? %>
-  <%= link_to_with_icon 'edit', Spree.t('dandify.admin.buttons.edit'), edit_admin_stylesheets_path, class: 'button' %>
-<% else %>
-  <%= link_to_with_icon 'plus', Spree.t('dandify.admin.buttons.new'), new_admin_stylesheets_path, class: 'btn btn-success' %>
+  <% if @style.persisted? %>
+    <%= link_to_with_icon 'edit', Spree.t('dandify.admin.buttons.edit'), edit_admin_stylesheets_path, class: 'btn btn-success' %>
+    <%= link_to_destroy_url %>
+  <% else %>
+    <%= link_to_with_icon 'plus', Spree.t('dandify.admin.buttons.new'), new_admin_stylesheets_path, class: 'btn btn-success' %>
+  <% end %>
 <% end %>
+
+<% content_for :head do %>
+  <%= stylesheet_link_tag 'https://cdnjs.cloudflare.com/ajax/libs/prism/0.0.1/prism.min.css' %>
+  <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/prism/0.0.1/prism.min.js' %>
 <% end %>
 
 <p class="notice"><%= notice %></p>
 
 <% if @style.persisted? %>
-  <%= render partial: 'versions', locals: { versions: @style.versions } %>
+  <pre><code class="language-css"><%= @style.style_raw %></code></pre>
+
 <% else %>
   <div class="no-objects-found">
     <%= Spree.t('dandify.admin.no_resource_found') %>,
     <%= link_to Spree.t('dandify.admin.create_one'), new_admin_stylesheets_path %>!
   </div>
 <% end %>
+
+<div class="row">
+  <% if PaperTrail::Version.count > 1 %>
+    <%= render partial: 'versions', locals: { versions: previous_versions } %>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,17 +3,24 @@ en:
   spree:
     dandify:
       admin:
+        action:
+          create: Created
+          update: Revised
+          destroy: Deleted
         unknown: Unknown
         no_resource_found: No stylesheet found
         create_one: Let's get dandy
         sidebar: Store Stylesheet
         confirm:
           restore: Are you sure you want to restore this version of the stylesheet?
+          destroy: Are you sure you want to delete your stylesheet?
         buttons:
           new: Create Stylesheet
-          edit: Edit Stylesheet
+          edit: Edit
+          destroy: Delete
         icons:
           restore: Restore
+          destroy: Destroy
         title:
           show: Custom Styles
           new: Creating Custom Styles
@@ -23,11 +30,14 @@ en:
             new: New stylesheet has been created.
             edit: Stylesheet has been updated. A new revision has been created.
             restore: Stylesheet has been restored. A new revision has been created.
+            destroyed: Stylesheet has been destroyed. A new revision has been created.
           error:
             restore: Unable to restore stylesheet.
         headers:
-          created_at: Created
+          on: On
           author: Author
+          action: Action
+          revision: Revisions
         labels: &dandify_labels
           style_raw: Styles
         notes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,7 @@
 Spree::Core::Engine.add_routes do
   namespace :admin do
     resource :stylesheets do
-      collection do
-        post :restore
-      end
+      post :restore
     end
   end
 

--- a/lib/dandify/version.rb
+++ b/lib/dandify/version.rb
@@ -1,3 +1,3 @@
 module Dandify
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end

--- a/spec/controllers/spree/admin/stylesheets_controller_spec.rb
+++ b/spec/controllers/spree/admin/stylesheets_controller_spec.rb
@@ -2,78 +2,124 @@ require 'spec_helper'
 
 module Spree
   module Admin
-  describe StylesheetsController, type: :controller do
-    stub_authorization!
+    describe StylesheetsController, type: :controller do
+      stub_authorization!
 
-    let(:show_path) { spree.admin_stylesheets_path }
-    let(:good_style) { 'body {color:#ffff00;}' }
-    let(:bad_style) { 'body {color:#ffff00;' }
+      let(:show_path) { spree.admin_stylesheets_path }
+      let(:good_style) { 'body {color:#ffff00;}' }
+      let(:bad_style) { 'body {color:#ffff00;' }
 
-    before do
-      user = create :admin_user
-      controller.stub(try_spree_current_user: user)
+      before do
+        user = create :admin_user
+        controller.stub(try_spree_current_user: user)
+      end
+
+      describe 'GET #show' do
+        it 'assigns new instance when none is found' do
+          spree_get :show
+
+          expect(assigns[:style]).to be_new_record
+        end
+
+        it 'assigns existing' do
+          style = create :stylesheet
+
+          spree_get :show
+
+          expect(assigns[:style]).to eq style
+        end
+      end
+
+      describe 'GET #new' do
+        it 'renders template' do
+          spree_get :new
+
+          expect(response).to render_template(:new)
+        end
+      end
+
+      describe 'POST #create' do
+        it 'redirects to show with good data' do
+          spree_post :create,
+                     stylesheet: { style_raw: '#main { display: inline; }' }
+
+          expect(response).to redirect_to(admin_stylesheets_path)
+        end
+
+        it 'renders new with bad data' do
+          spree_post :create, stylesheet: { style_raw: bad_style }
+
+          expect(response).to render_template(:new)
+        end
+      end
+
+      describe 'GET #edit' do
+        it 'can create a revision' do
+          stylesheet = create :stylesheet
+
+          spree_get :edit
+
+          expect(assigns[:style]).to eq stylesheet
+        end
+      end
+
+      describe 'PUT #update' do
+        before { create :stylesheet }
+
+        it 'redirects to show with good data' do
+          spree_post :update,
+                     stylesheet: { style_raw: '#main { display: inline; }' }
+
+          expect(response).to redirect_to(admin_stylesheets_path)
+        end
+
+        it 'renders edit with bad data' do
+          spree_post :update, stylesheet: { style_raw: bad_style }
+
+          expect(response).to render_template(:edit)
+        end
+      end
+
+      describe 'POST #restore', versioning: true do
+        before { create :stylesheet }
+
+        it 'fails to reify when there is only one revision' do
+          spree_post :restore
+
+          expect(flash[:error]).to eq(
+            Spree.t('dandify.admin.flash.error.restore')
+          )
+
+          expect(response).to redirect_to show_path
+        end
+
+        it 'able to reify when there is more than one revision' do
+          style = Spree::Stylesheet.first
+
+          style.update_attributes style_raw: '#main { display: block; }'
+          style.update_attributes style_raw: '#main { display: none; }'
+
+          spree_post :restore, id: PaperTrail::Version.second.id
+
+          expect(flash[:success]).to eq(
+            Spree.t('dandify.admin.flash.success.restore')
+          )
+          expect(response).to redirect_to show_path
+        end
+      end
+
+      describe 'DELETE #destroy' do
+        it 'sends #destroy to returned model from #first_or_initialize' do
+          fake_stylesheet = instance_double(Spree::Stylesheet, destroy: true)
+          allow(Spree::Stylesheet).to receive(:first_or_initialize).
+            and_return fake_stylesheet
+
+          spree_delete :destroy
+
+          expect(fake_stylesheet).to have_received(:destroy)
+          expect(response).to redirect_to admin_stylesheets_path
+        end
+      end
     end
-
-    context '#show' do
-      it 'assigns new instance when none is found' do
-        spree_get :show
-        expect(assigns[:style]).to be_new_record
-      end
-
-      it 'assigns existing' do
-        style = create :stylesheet
-        spree_get :show
-        expect(assigns[:style]).to eq style
-      end
-    end
-
-    context '#new' do
-      it 'can create first a revision' do
-        style = create :stylesheet
-        spree_get :show
-        expect(assigns[:style]).to eq style
-        expect(response).to render_template(:show)
-      end
-
-      it 'can not create first revision because error' do
-        spree_post :create, stylesheet: { style_raw: bad_style }
-        expect(response).to render_template(:new)
-      end
-    end
-
-    context '#edit' do
-      it 'can create a revision' do
-        create :stylesheet
-        spree_get :show
-        expect(response).to render_template(:show)
-      end
-
-      it 'can not create a revision because error' do
-        spree_post :update, stylesheet: { style_raw: bad_style }
-        expect(response).to render_template(:edit)
-      end
-    end
-
-    context '#restore', versioning: true do
-      before { create :stylesheet }
-
-      it 'fails to reify when there is only one revision' do
-        spree_post :restore
-        expect(flash[:error]).to eq(
-          Spree.t('dandify.admin.flash.error.restore')
-        )
-        expect(response).to redirect_to show_path
-      end
-
-      it 'able to reify when there is more than one revision' do
-        spree_post :update, stylesheet: { style_raw: good_style }
-        spree_post :restore
-        expect(flash[:success]).to eq(
-          Spree.t('dandify.admin.flash.success.restore')
-        )
-        expect(response).to redirect_to show_path
-      end
-    end
-  end
   end
 end

--- a/spec/features/managing_stylesheet_spec.rb
+++ b/spec/features/managing_stylesheet_spec.rb
@@ -28,17 +28,27 @@ feature 'Managing stylesheets' do
     end
   end
 
-  context 'with existing style' do
+  context 'with existing style', versioning: true do
     before { create :stylesheet }
 
-    scenario 'user sees first audit trail', versioning: true do
+    scenario 'user does not see audit trail with no revisions' do
       visit show_path
 
-      expect(page).to have_css(css_path, count: 1)
+      expect(page).not_to have_css(css_path, count: 1)
+    end
+
+    scenario 'after first edit user can see previous revisions' do
+      visit edit_path
+
+      fill_in Spree.t('dandify.admin.labels.style_raw'), with: '.moon { display: none}'
+      click_button Spree.t(:update)
+
+      expect(page).to have_css(css_path, count: 2)
     end
 
     scenario 'user can edit exiting styles' do
       visit edit_path
+
       fill_in Spree.t('dandify.admin.labels.style_raw'), with: style
       click_button Spree.t(:update)
 
@@ -61,7 +71,7 @@ feature 'Managing stylesheets' do
     scenario 'not possible when there is only one version', versioning: true do
       visit show_path
 
-      expect(page).to have_css(css_path, count: 1)
+      expect(page).not_to have_css(css_path)
     end
 
     scenario 'user can restore to previous version', versioning: true, js: true do

--- a/spec/helpers/admin/stylesheet_helper_spec.rb
+++ b/spec/helpers/admin/stylesheet_helper_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+module Spree
+  module Admin
+    describe StylesheetHelper do
+      describe '#dandify_version_email' do
+        context 'with nil or unknown values' do
+          let(:fake_unknown_user) { instance_double(UnknownUser, email: 'foo') }
+
+          before do
+            allow(UnknownUser).to receive(:new) { fake_unknown_user }
+          end
+
+          context 'when user_id is nil' do
+            it 'instantiates a new UknownUser and calls #email' do
+              helper.dandify_version_email(nil)
+
+              expect(UnknownUser).to have_received(:new)
+              expect(fake_unknown_user).to have_received(:email)
+            end
+          end
+
+          context 'when user_id equals Spree.t("dandify.admin.unknown")' do
+            it 'instantiates a new UknownUser and calls #email' do
+              helper.dandify_version_email(Spree.t('dandify.admin.unknown'))
+
+              expect(UnknownUser).to have_received(:new)
+              expect(fake_unknown_user).to have_received(:email)
+            end
+          end
+        end
+
+        context 'with everything else' do
+          it 'sends user_id to User#find and calls email' do
+            fake_user = instance_double(User, email: 'foo')
+            allow(User).to receive(:find) { fake_user }
+
+            helper.dandify_version_email('1')
+
+            expect(User).to have_received(:find).with '1'
+            expect(fake_user).to have_received(:email)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What's new?

* Prism for displaying current styling awesomeness!
![screen shot 2015-08-19 at 3 25 20 pm](https://cloud.githubusercontent.com/assets/328428/9370632/8d2820bc-4686-11e5-8bcd-7e0aaaedfaed.png)
* Ace editor setup for CSS editing awesomeness!
![screen shot 2015-08-19 at 3 25 30 pm](https://cloud.githubusercontent.com/assets/328428/9370643/a20d417e-4686-11e5-9f80-cb13d456cc3c.png)
* Ability to restore a deletion!
* Ability to restore to a specific revision!
* Cleaned up specs
* Add some null objects to simplify logic